### PR TITLE
feat: StoreKit 결제 기능 구현

### DIFF
--- a/Junction.xcodeproj/project.pbxproj
+++ b/Junction.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -63,6 +63,11 @@
 		074148ED2C68410200D79562 /* ResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074148EC2C68410200D79562 /* ResultViewModel.swift */; };
 		074148EF2C68418F00D79562 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074148EE2C68418F00D79562 /* LoadingView.swift */; };
 		074148F32C68427A00D79562 /* loadingAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 074148F22C68427A00D79562 /* loadingAnimation.json */; };
+		07590B2C2C9D99DF00BE6B14 /* PaymentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07590B2B2C9D99DF00BE6B14 /* PaymentView.swift */; };
+		07590B312C9D9BBE00BE6B14 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07590B302C9D9BBE00BE6B14 /* StoreKit.framework */; };
+		07590B392C9DACCC00BE6B14 /* Products.plist in Resources */ = {isa = PBXBuildFile; fileRef = 07590B382C9DACCC00BE6B14 /* Products.plist */; };
+		07A275232CB61A120043B767 /* Prelude(프렐류드).storekit in Resources */ = {isa = PBXBuildFile; fileRef = 07A275222CB61A120043B767 /* Prelude(프렐류드).storekit */; };
+		07DC00592CACDF40003E99FA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 07DC00582CACDF40003E99FA /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -124,7 +129,17 @@
 		074148EC2C68410200D79562 /* ResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewModel.swift; sourceTree = "<group>"; };
 		074148EE2C68418F00D79562 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		074148F22C68427A00D79562 /* loadingAnimation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = loadingAnimation.json; sourceTree = "<group>"; };
+		07590B2B2C9D99DF00BE6B14 /* PaymentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentView.swift; sourceTree = "<group>"; };
+		07590B302C9D9BBE00BE6B14 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		07590B382C9DACCC00BE6B14 /* Products.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Products.plist; sourceTree = "<group>"; };
+		07A275222CB61A120043B767 /* Prelude(프렐류드).storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Prelude(프렐류드).storekit"; sourceTree = "<group>"; };
+		07DC00582CACDF40003E99FA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		07A275242CB622B60043B767 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		07DC00742CB4112C003E99FA /* Errors */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Errors; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		071C83D52C66E1CB0055C393 /* Frameworks */ = {
@@ -132,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				074148CD2C67F66100D79562 /* Lottie in Frameworks */,
+				07590B312C9D9BBE00BE6B14 /* StoreKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,7 +157,9 @@
 		071C83CF2C66E1CB0055C393 = {
 			isa = PBXGroup;
 			children = (
+				07DC00582CACDF40003E99FA /* Localizable.xcstrings */,
 				071C83DA2C66E1CB0055C393 /* Junction */,
+				07590B2F2C9D9BBE00BE6B14 /* Frameworks */,
 				071C83D92C66E1CB0055C393 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -157,6 +175,7 @@
 		071C83DA2C66E1CB0055C393 /* Junction */ = {
 			isa = PBXGroup;
 			children = (
+				07A275242CB622B60043B767 /* Shared */,
 				074148D52C6800F300D79562 /* Resources */,
 				071C843A2C66E3690055C393 /* Info.plist */,
 				071C83F42C66E30A0055C393 /* Data */,
@@ -167,6 +186,8 @@
 				071C83E12C66E1CC0055C393 /* Junction.entitlements */,
 				071C84382C66E3260055C393 /* Secrets.xcconfig */,
 				071C83E22C66E1CC0055C393 /* Preview Content */,
+				07A275222CB61A120043B767 /* Prelude(프렐류드).storekit */,
+				07590B382C9DACCC00BE6B14 /* Products.plist */,
 			);
 			path = Junction;
 			sourceTree = "<group>";
@@ -248,6 +269,7 @@
 				074148E32C681B2A00D79562 /* HealthCheckView.swift */,
 				074148EA2C683F8300D79562 /* ResultView.swift */,
 				074148EE2C68418F00D79562 /* LoadingView.swift */,
+				07590B2B2C9D99DF00BE6B14 /* PaymentView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -357,6 +379,7 @@
 		071C84192C66E30A0055C393 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				07DC00742CB4112C003E99FA /* Errors */,
 				071C840A2C66E30A0055C393 /* Entities */,
 				071C84122C66E30A0055C393 /* Interfaces */,
 				071C84182C66E30A0055C393 /* UseCases */,
@@ -418,6 +441,14 @@
 			path = Health;
 			sourceTree = "<group>";
 		};
+		07590B2F2C9D9BBE00BE6B14 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				07590B302C9D9BBE00BE6B14 /* StoreKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -432,6 +463,10 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				07A275242CB622B60043B767 /* Shared */,
+				07DC00742CB4112C003E99FA /* Errors */,
 			);
 			name = Junction;
 			packageProductDependencies = (
@@ -463,6 +498,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"ko-KR",
 			);
 			mainGroup = 071C83CF2C66E1CB0055C393;
 			packageReferences = (
@@ -484,12 +520,15 @@
 			files = (
 				074148DE2C6801CD00D79562 /* Pretendard-Medium.otf in Resources */,
 				071C83E42C66E1CC0055C393 /* Preview Assets.xcassets in Resources */,
+				07590B392C9DACCC00BE6B14 /* Products.plist in Resources */,
 				074148DC2C68012C00D79562 /* Pretendard-Bold.otf in Resources */,
 				071C83E02C66E1CC0055C393 /* Assets.xcassets in Resources */,
+				07DC00592CACDF40003E99FA /* Localizable.xcstrings in Resources */,
 				074148DB2C68012C00D79562 /* Pretendard-Regular.otf in Resources */,
 				071C84392C66E3260055C393 /* Secrets.xcconfig in Resources */,
 				074148F32C68427A00D79562 /* loadingAnimation.json in Resources */,
 				074148DA2C68012C00D79562 /* Pretendard-SemiBold.otf in Resources */,
+				07A275232CB61A120043B767 /* Prelude(프렐류드).storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -537,6 +576,7 @@
 				071C83DC2C66E1CB0055C393 /* JunctionApp.swift in Sources */,
 				071C84292C66E30A0055C393 /* RetrieveMessageResponse.swift in Sources */,
 				071C842A2C66E30A0055C393 /* RunRequest.swift in Sources */,
+				07590B2C2C9D99DF00BE6B14 /* PaymentView.swift in Sources */,
 				071C842E2C66E30A0055C393 /* AssistantInteractionFacade.swift in Sources */,
 				074148D42C6800CA00D79562 /* Font+.swift in Sources */,
 				071C842C2C66E30A0055C393 /* RunStepResponse.swift in Sources */,
@@ -610,6 +650,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -664,6 +705,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Release;
 		};
@@ -682,6 +724,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Junction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Prelude;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진첩 접근에 허용해주세요";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -699,7 +742,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eric.Junction;
+				PRODUCT_BUNDLE_IDENTIFIER = Eric.motive.prelude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -725,6 +768,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Junction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Prelude;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진첩 접근에 허용해주세요";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -742,7 +786,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eric.Junction;
+				PRODUCT_BUNDLE_IDENTIFIER = Eric.motive.prelude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Junction.xcodeproj/xcshareddata/xcschemes/Junction.xcscheme
+++ b/Junction.xcodeproj/xcshareddata/xcschemes/Junction.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "071C83D72C66E1CB0055C393"
+               BuildableName = "Junction.app"
+               BlueprintName = "Junction"
+               ReferencedContainer = "container:Junction.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "071C83D72C66E1CB0055C393"
+            BuildableName = "Junction.app"
+            BlueprintName = "Junction"
+            ReferencedContainer = "container:Junction.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "071C83D72C66E1CB0055C393"
+            BuildableName = "Junction.app"
+            BlueprintName = "Junction"
+            ReferencedContainer = "container:Junction.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Junction.xcodeproj/xcuserdata/eric.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Junction.xcodeproj/xcuserdata/eric.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,13 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>071C83D72C66E1CB0055C393</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Junction/Domain/Errors/StoreError.swift
+++ b/Junction/Domain/Errors/StoreError.swift
@@ -1,0 +1,14 @@
+//
+//  StoreError.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/7/24.
+//
+
+
+public enum StoreError: Error {
+    case failedVerification
+    case insufficientFunds
+    case networkUnavailable
+    case unknownError
+}

--- a/Junction/JunctionApp.swift
+++ b/Junction/JunctionApp.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 @main
 struct JunctionApp: App {
+    @StateObject var store = Store()
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(NavigationManager())
+                .environmentObject(store)
         }
     }
 }

--- a/Junction/Prelude(프렐류드).storekit
+++ b/Junction/Prelude(프렐류드).storekit
@@ -1,0 +1,95 @@
+{
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
+  "identifier" : "AC71D736",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "0.99",
+      "familyShareable" : false,
+      "internalID" : "6702022520",
+      "localizations" : [
+        {
+          "description" : "테스트 용 상품입니다.",
+          "displayName" : "결제테스트",
+          "locale" : "ko"
+        }
+      ],
+      "productID" : "PreludePurchaseTest.motive.prelude",
+      "referenceName" : "Prelude-Purchase",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "6670449153",
+    "_developerTeamID" : "VGKCD7Q8NW",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 750131733.84833395,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
+  },
+  "subscriptionGroups" : [
+
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/Junction/Presentation/ViewModels/ResultViewModel.swift
+++ b/Junction/Presentation/ViewModels/ResultViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class ResultViewModel: ObservableObject {
     private let assistantInteractionFacade: AssistantInteractionFacadeImpl
     
-    private var cancellables = Set<AnyCancellable>()
+    var cancellables = Set<AnyCancellable>()
     @Published var receivedMessage: String?
     @Published var imageErrorMessage: String?
     @Published var userHealthInfo: HealthInfo?

--- a/Junction/Presentation/Views/PaymentView.swift
+++ b/Junction/Presentation/Views/PaymentView.swift
@@ -1,0 +1,46 @@
+//
+//  PaymentView.swift
+//  Junction
+//
+//  Created by 송지혁 on 9/20/24.
+//
+
+import SwiftUI
+import StoreKit
+
+struct PaymentView: View {
+    @EnvironmentObject var store: Store
+    @State private var sliderValue: Double = 0
+    
+    var body: some View {
+        VStack {
+            Text(store.value.description)
+                .font(.headline)
+            
+            
+            Slider(value: $sliderValue, in: 0...100, step: 1)
+            
+            Text("\(Int(sliderValue))$")
+                .monospacedDigit()
+            
+            ForEach(store.test, id: \.self) { product in
+                Text("Purchase")
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, maxHeight: 60)
+                    .background { RoundedRectangle(cornerRadius: 16).fill(.blue) }
+                    .onTapGesture {
+                        Task { await store.purchase(product) }
+                    }
+            }
+        }
+        .padding()
+        .alert("결제 실패", isPresented: $store.showAlert) { } message: {
+            Text(store.errorMessage)
+        }
+    }
+}
+
+#Preview {
+    PaymentView()
+        .environmentObject(Store())
+}

--- a/Junction/Presentation/Views/ResultView.swift
+++ b/Junction/Presentation/Views/ResultView.swift
@@ -5,6 +5,7 @@
 //  Created by 송지혁 on 8/11/24.
 //
 
+import Combine
 import SwiftUI
 
 enum JudgeResult {
@@ -26,6 +27,17 @@ struct ResultView: View {
                 LoadingView()
                     .onAppear {
                         resultViewModel.sendMessage(userSelectedPrompt, image: image)
+                            .sink { completion in
+                                switch completion {
+                                    case .failure(let error):
+                                        dismiss()
+                                    case .finished:
+                                        print("good")
+                                }
+                            } receiveValue: { _ in
+                                
+                            }
+                            .store(in: &resultViewModel.cancellables)
                     }
             } else {
                 resultView
@@ -162,3 +174,4 @@ struct ResultView: View {
         .padding(.bottom, 24)
     }
 }
+

--- a/Junction/Products.plist
+++ b/Junction/Products.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreludePurchaseTest.motive.prelude</key>
+	<string>Test</string>
+</dict>
+</plist>

--- a/Junction/Shared/Store.swift
+++ b/Junction/Shared/Store.swift
@@ -1,0 +1,120 @@
+//
+//  Store.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/9/24.
+//
+
+import Foundation
+import StoreKit
+
+class Store: ObservableObject {
+    @Published private(set) var products: [String: String]
+    @Published private(set) var test: [Product]
+    @Published private(set) var value = 0
+    @Published var errorMessage = ""
+    @Published var showAlert = false
+    
+    var updateListenerTask: Task<Void, Error>? = nil
+    
+    init() {
+        products = Store.loadProducts()
+        
+        test = []
+        updateListenerTask = listenForTransactions()
+        
+        Task {
+            await self.requestProducts()
+        }
+    }
+    
+    static func loadProducts() -> [String: String] {
+        guard let path = Bundle.main.path(forResource: "Products", ofType: "plist"),
+              let plist = FileManager.default.contents(atPath: path),
+              let data = try? PropertyListSerialization.propertyList(from: plist, options: [], format: nil) as? [String: String] else { return [:] }
+        
+        return data
+    }
+    
+    @MainActor
+    func requestProducts() async {
+        do {
+            let storeProducts = try await Product.products(for: products.keys)
+            
+            for product in storeProducts {
+                switch product.type {
+                    default:
+                        test.append(product)
+                }
+            }
+        } catch {
+            print("Error")
+        }
+    }
+    
+    func listenForTransactions() -> Task<Void, Error> {
+        return Task.detached {
+            for await result in Transaction.updates {
+                do {
+                    let transaction = try self.checkVerified(result)
+                    await transaction.finish()
+                } catch { self.handleError(StoreError.failedVerification) }
+            }
+        }
+    }
+    
+    @MainActor
+    func purchase(_ product: Product) async -> StoreKit.Transaction? {
+        do {
+            let result = try await product.purchase()
+            
+            switch result {
+                case .success(let verification):
+                    let transaction = try checkVerified(verification)
+                    incrementCount(10)
+                    await transaction.finish()
+
+                    return transaction
+                    
+                case .pending: print("팬다 진짜")
+                case .userCancelled: print("굳")
+            }
+        } catch let error as StoreKitError {
+            switch error {
+                case .notEntitled:
+                    handleError(StoreError.failedVerification)
+                case .networkError:
+                    handleError(StoreError.networkUnavailable)
+                default: handleError(StoreError.unknownError)
+            }
+        } catch { handleError(StoreError.unknownError) }
+        
+        return nil
+    }
+    
+    private func incrementCount(_ n: Int) { self.value += n }
+    
+    private func handleError(_ error: StoreError) {
+        switch error {
+            case .failedVerification:
+                self.errorMessage = "Failed to verify your purchase."
+            case .insufficientFunds:
+                self.errorMessage = "Insufficient funds for the purchase."
+            case .networkUnavailable:
+                self.errorMessage = "Network is unavailable. Please check your connection."
+            case .unknownError:
+                self.errorMessage = "An unknown error occurred. Please try again."
+        }
+        
+        self.showAlert = true
+    }
+    
+    func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+            case .unverified:
+                throw StoreError.failedVerification
+            case .verified(let safe):
+                return safe
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

StoreKit 프레임워크를 통해 IAP(In App Purchase) 기능을 구현했습니다.


## 🔐 세부 내용
> ### Product 리스트 추가 및 연동
>-  App Store Connect에서 앱 내 소모품 상품(테스트용 상품)을 추가하고 Storekit Configuration File에서 연동했습니다.
>- 상품의 ID를 Products.plist 파일로 관리하여 코드와 데이터를 분리했습니다.

<br />

> ### StoreKit Purchase 구현
>- 결제 과정(인 앱 상품 load -> purchase 시도 -> 사용자 verification 인증 -> 구매 완료)을 Swift Concurrency를 이용하여 구현했습니다.
>- 결제와 관련된 로직은 Store class에 구현되어있습니다.

<br />

> ### 정상적으로 완료되지 않은 Transaction은 어떻게 관리되는가?
>- 결제 도중 네트워크가 끊기거나 앱이 종료되는 상황이 발생 했을 때, 진행 중이었던 Transaction이 추후 결제 상황에 문제가 될 수 있다는 가설 하에 어떻게 이 상황을 관리해야할까 고민해보았습니다.

> -> Store class가 initialize될 때, `for await` 문법을 이용한 Task를 프로퍼티에 할당하여 백그라운드에서 Transaction.update(`AsyncSequence`)에 남아있는 Transaction을 실시간으로 감지하고 처리할 수 있었습니다.

<br />

```swift   
 var updateListenerTask: Task<Void, Error>? = nil

 init() {
      updateListenerTask = listenForTransactions()
 }

 func listenForTransactions() -> Task<Void, Error> {
        return Task.detached {
            for await result in Transaction.updates {
                do {
                    let transaction = try self.checkVerified(result)
                    await transaction.finish()
                } catch { self.handleError(StoreError.failedVerification) }
            }
        }
    }
```

<br />

> ### Transactions Local Test
>- Xcode에서 Storekit Transaction Manager를 통해  StoreKit의 Transaction을 Local에서 발생시켜 테스트했습니다.
>- 인 앱 상품 로드를 실패하는 상황, 사용자 인증에 실패한 상황, 구매 시 네트워크 오류 상황을 로컬로 테스트하여 상황에 맞는 
error message를 표시하는걸 확인할 수 있었습니다.

https://github.com/user-attachments/assets/110440dc-dc2d-436e-bb5f-abff9468d3c1

