### PR TITLE
feat: CloudKit 유저 데이터 연동 기능 구현

### DIFF
--- a/Junction.xcodeproj/project.pbxproj
+++ b/Junction.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -63,6 +63,12 @@
 		074148ED2C68410200D79562 /* ResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074148EC2C68410200D79562 /* ResultViewModel.swift */; };
 		074148EF2C68418F00D79562 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074148EE2C68418F00D79562 /* LoadingView.swift */; };
 		074148F32C68427A00D79562 /* loadingAnimation.json in Resources */ = {isa = PBXBuildFile; fileRef = 074148F22C68427A00D79562 /* loadingAnimation.json */; };
+		074BFFE42CB937D4000773CA /* SwiftDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074BFFE32CB937D4000773CA /* SwiftDataManager.swift */; };
+		074BFFE62CBA2ADC000773CA /* CloudKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074BFFE52CBA2ADC000773CA /* CloudKitManager.swift */; };
+		074BFFE82CBA3CBA000773CA /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074BFFE72CBA3CBA000773CA /* Convertible.swift */; };
+		074BFFEA2CBAA940000773CA /* HealthCheckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074BFFE92CBAA940000773CA /* HealthCheckViewModel.swift */; };
+		07590B312C9D9BBE00BE6B14 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07590B302C9D9BBE00BE6B14 /* StoreKit.framework */; };
+		07DC00592CACDF40003E99FA /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 07DC00582CACDF40003E99FA /* Localizable.xcstrings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -124,7 +130,19 @@
 		074148EC2C68410200D79562 /* ResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultViewModel.swift; sourceTree = "<group>"; };
 		074148EE2C68418F00D79562 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		074148F22C68427A00D79562 /* loadingAnimation.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = loadingAnimation.json; sourceTree = "<group>"; };
+		074BFFE32CB937D4000773CA /* SwiftDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataManager.swift; sourceTree = "<group>"; };
+		074BFFE52CBA2ADC000773CA /* CloudKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitManager.swift; sourceTree = "<group>"; };
+		074BFFE72CBA3CBA000773CA /* Convertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Convertible.swift; sourceTree = "<group>"; };
+		074BFFE92CBAA940000773CA /* HealthCheckViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCheckViewModel.swift; sourceTree = "<group>"; };
+		07590B302C9D9BBE00BE6B14 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		07DC00582CACDF40003E99FA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		07A643E82CB62A5000AA4EB2 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		07A643E92CB65EF700AA4EB2 /* UserInfo */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = UserInfo; sourceTree = "<group>"; };
+		07DC00742CB4112C003E99FA /* Errors */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Errors; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		071C83D52C66E1CB0055C393 /* Frameworks */ = {
@@ -132,6 +150,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				074148CD2C67F66100D79562 /* Lottie in Frameworks */,
+				07590B312C9D9BBE00BE6B14 /* StoreKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,7 +160,9 @@
 		071C83CF2C66E1CB0055C393 = {
 			isa = PBXGroup;
 			children = (
+				07DC00582CACDF40003E99FA /* Localizable.xcstrings */,
 				071C83DA2C66E1CB0055C393 /* Junction */,
+				07590B2F2C9D9BBE00BE6B14 /* Frameworks */,
 				071C83D92C66E1CB0055C393 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -157,6 +178,7 @@
 		071C83DA2C66E1CB0055C393 /* Junction */ = {
 			isa = PBXGroup;
 			children = (
+				07A643E82CB62A5000AA4EB2 /* Shared */,
 				074148D52C6800F300D79562 /* Resources */,
 				071C843A2C66E3690055C393 /* Info.plist */,
 				071C83F42C66E30A0055C393 /* Data */,
@@ -221,8 +243,10 @@
 		071C83F72C66E30A0055C393 /* Infrastructure */ = {
 			isa = PBXGroup;
 			children = (
+				074BFFE32CB937D4000773CA /* SwiftDataManager.swift */,
 				071C83F52C66E30A0055C393 /* DIContainer.swift */,
 				071C83F62C66E30A0055C393 /* NavigationManager.swift */,
+				074BFFE52CBA2ADC000773CA /* CloudKitManager.swift */,
 			);
 			path = Infrastructure;
 			sourceTree = "<group>";
@@ -233,6 +257,7 @@
 				071C83F82C66E30A0055C393 /* MainViewModel.swift */,
 				074148E82C68206A00D79562 /* HealthSetUpViewModel.swift */,
 				074148EC2C68410200D79562 /* ResultViewModel.swift */,
+				074BFFE92CBAA940000773CA /* HealthCheckViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -301,6 +326,7 @@
 		071C840A2C66E30A0055C393 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				07A643E92CB65EF700AA4EB2 /* UserInfo */,
 				074148E52C681D7E00D79562 /* Health */,
 				074148C62C67EDA800D79562 /* Judgement */,
 				071C84412C6704710055C393 /* File */,
@@ -337,6 +363,7 @@
 			children = (
 				071C840C2C66E30A0055C393 /* Facades */,
 				071C84112C66E30A0055C393 /* Repositories */,
+				074BFFE72CBA3CBA000773CA /* Convertible.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -357,6 +384,7 @@
 		071C84192C66E30A0055C393 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				07DC00742CB4112C003E99FA /* Errors */,
 				071C840A2C66E30A0055C393 /* Entities */,
 				071C84122C66E30A0055C393 /* Interfaces */,
 				071C84182C66E30A0055C393 /* UseCases */,
@@ -418,6 +446,14 @@
 			path = Health;
 			sourceTree = "<group>";
 		};
+		07590B2F2C9D9BBE00BE6B14 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				07590B302C9D9BBE00BE6B14 /* StoreKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -432,6 +468,11 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				07A643E82CB62A5000AA4EB2 /* Shared */,
+				07A643E92CB65EF700AA4EB2 /* UserInfo */,
+				07DC00742CB4112C003E99FA /* Errors */,
 			);
 			name = Junction;
 			packageProductDependencies = (
@@ -463,6 +504,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"ko-KR",
 			);
 			mainGroup = 071C83CF2C66E1CB0055C393;
 			packageReferences = (
@@ -486,6 +528,7 @@
 				071C83E42C66E1CC0055C393 /* Preview Assets.xcassets in Resources */,
 				074148DC2C68012C00D79562 /* Pretendard-Bold.otf in Resources */,
 				071C83E02C66E1CC0055C393 /* Assets.xcassets in Resources */,
+				07DC00592CACDF40003E99FA /* Localizable.xcstrings in Resources */,
 				074148DB2C68012C00D79562 /* Pretendard-Regular.otf in Resources */,
 				071C84392C66E3260055C393 /* Secrets.xcconfig in Resources */,
 				074148F32C68427A00D79562 /* loadingAnimation.json in Resources */,
@@ -514,10 +557,12 @@
 				071C84432C6704800055C393 /* FileUploadResponse.swift in Sources */,
 				071C84342C66E30A0055C393 /* CreateRunUseCase.swift in Sources */,
 				074148D12C68004F00D79562 /* OnboardingView.swift in Sources */,
+				074BFFE42CB937D4000773CA /* SwiftDataManager.swift in Sources */,
 				074148EF2C68418F00D79562 /* LoadingView.swift in Sources */,
 				071C84202C66E30A0055C393 /* ThreadRepositoryImpl.swift in Sources */,
 				071C84302C66E30A0055C393 /* RunRepository.swift in Sources */,
 				071C84372C66E30B0055C393 /* RetrieveMessageUseCase.swift in Sources */,
+				074BFFE82CBA3CBA000773CA /* Convertible.swift in Sources */,
 				074148E42C681B2A00D79562 /* HealthCheckView.swift in Sources */,
 				071C84352C66E30B0055C393 /* CreateThreadUseCase.swift in Sources */,
 				071C841B2C66E30A0055C393 /* EndPoint.swift in Sources */,
@@ -542,8 +587,10 @@
 				071C842C2C66E30A0055C393 /* RunStepResponse.swift in Sources */,
 				071C84312C66E30A0055C393 /* RunStepRepository.swift in Sources */,
 				071C84242C66E30A0055C393 /* ContentView.swift in Sources */,
+				074BFFEA2CBAA940000773CA /* HealthCheckViewModel.swift in Sources */,
 				071C84262C66E30A0055C393 /* CreateMessageResponse.swift in Sources */,
 				071C84272C66E30A0055C393 /* Message.swift in Sources */,
+				074BFFE62CBA2ADC000773CA /* CloudKitManager.swift in Sources */,
 				071C841D2C66E30A0055C393 /* MessageRepositoryImpl.swift in Sources */,
 				071C84232C66E30A0055C393 /* MainViewModel.swift in Sources */,
 				071C842F2C66E30A0055C393 /* MessageRepository.swift in Sources */,
@@ -610,6 +657,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -664,6 +712,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Release;
 		};
@@ -682,6 +731,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Junction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Prelude;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진첩 접근에 허용해주세요";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -699,7 +749,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eric.Junction;
+				PRODUCT_BUNDLE_IDENTIFIER = Eric.motive.prelude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -725,6 +775,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Junction/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Prelude;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSCameraUsageDescription = "사진첩 접근에 허용해주세요";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -742,7 +793,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.1;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eric.Junction;
+				PRODUCT_BUNDLE_IDENTIFIER = Eric.motive.prelude;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Junction/Domain/Entities/Health/HealthInfo.swift
+++ b/Junction/Domain/Entities/Health/HealthInfo.swift
@@ -5,14 +5,32 @@
 //  Created by 송지혁 on 8/11/24.
 //
 
-struct HealthInfo: Equatable, Hashable, Codable {
-    var pregnantWeek: PregnantWeek
-    var height: String
-    var weight: String
-    var bloodPressure: BloodPresure
-    var diabetes: Diabetes
+import CloudKit
+import SwiftData
+
+@Model
+final class HealthInfo {
+    var id: String
+    var pregnantWeek: PregnantWeek = PregnantWeek.early
+    var height: String = ""
+    var weight: String = ""
+    var bloodPressure: BloodPresure = BloodPresure.normal
+    var diabetes: Diabetes = Diabetes.notAffected
     
     var bmi: Double {
-        return Double(weight)! / Double(height)! * Double(height)!
+        guard let weightValue = Double(weight), let heightValue = Double(height) else { return 0.0 }
+        return weightValue / heightValue * heightValue
+    }
+    
+    init(id: String = "HealthInfo", pregnantWeek: PregnantWeek, height: String, weight: String, bloodPressure: BloodPresure, diabetes: Diabetes) {
+        self.id = id
+        self.pregnantWeek = pregnantWeek
+        self.height = height
+        self.weight = weight
+        self.bloodPressure = bloodPressure
+        self.diabetes = diabetes
+    }
+}
+
     }
 }

--- a/Junction/Domain/Entities/Health/HealthInfo.swift
+++ b/Junction/Domain/Entities/Health/HealthInfo.swift
@@ -32,5 +32,32 @@ final class HealthInfo {
     }
 }
 
+extension HealthInfo: Convertible {
+    func toCKRecord() -> CKRecord {
+        let recordID = CKRecord.ID(recordName: self.id)
+        let record = CKRecord(recordType: "HealthInfo", recordID: recordID)
+        
+        record["pregnantWeek"] = self.pregnantWeek.rawValue as CKRecordValue
+        record["height"] = self.height as CKRecordValue
+        record["weight"] = self.weight as CKRecordValue
+        record["bloodPressure"] = self.bloodPressure.rawValue as CKRecordValue
+        record["diabetes"] = self.diabetes.rawValue as CKRecordValue
+        
+        return record
+    }
+    
+    convenience init?(from record: CKRecord) {
+        let id = record.recordID.recordName
+        guard let pregnantWeekRaw = record["pregnantWeek"] as? String,
+              let pregnantWeek = PregnantWeek(rawValue: pregnantWeekRaw),
+              let height = record["height"] as? String,
+              let weight = record["weight"] as? String,
+              let bloodPressureRaw = record["bloodPressure"] as? String,
+              let bloodPressure = BloodPresure(rawValue: bloodPressureRaw),
+              let diabetesRaw = record["diabetes"] as? String,
+              let diabetes = Diabetes(rawValue: diabetesRaw)
+        else { return nil }
+        
+        self.init(id: id, pregnantWeek: pregnantWeek, height: height, weight: weight, bloodPressure: bloodPressure, diabetes: diabetes)
     }
 }

--- a/Junction/Domain/Entities/UserInfo/UserInfo.swift
+++ b/Junction/Domain/Entities/UserInfo/UserInfo.swift
@@ -1,0 +1,47 @@
+//
+//  UserInfo.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/9/24.
+//
+
+import CloudKit
+import SwiftData
+import Foundation
+
+@Model
+final class UserInfo {
+    var id: String
+    var remainingTimes: Int = 0
+    var healthInfo: HealthInfo?
+    
+    init(id: String = "UserInfo", remainingTimes: Int, healthInfo: HealthInfo? = nil) {
+        self.id = id
+        self.remainingTimes = remainingTimes
+        self.healthInfo = healthInfo
+    }
+}
+
+extension UserInfo: Convertible {
+    func toCKRecord() -> CKRecord {
+        let recordID = CKRecord.ID(recordName: self.id)
+        let record = CKRecord(recordType: "UserInfo", recordID: recordID)
+        record["remainingTimes"] = self.remainingTimes as CKRecordValue
+        
+        if let healthInfo = healthInfo {
+            let healthInfoRecord = healthInfo.toCKRecord()
+            let reference = CKRecord.Reference(recordID: healthInfoRecord.recordID, action: .deleteSelf)
+            record["healthInfo"] = reference
+        }
+        
+        return record
+    }
+    
+    convenience init?(from record: CKRecord, healthInfo: HealthInfo) {
+        let id = record.recordID.recordName
+        guard let remainingTimes = record["remainingTimes"] as? Int else { return nil }
+        
+        
+        self.init(id: id, remainingTimes: remainingTimes, healthInfo: healthInfo)
+    }
+}

--- a/Junction/Domain/Interfaces/Convertible.swift
+++ b/Junction/Domain/Interfaces/Convertible.swift
@@ -1,0 +1,12 @@
+//
+//  Convertible.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/12/24.
+//
+
+import CloudKit
+
+protocol Convertible {
+    func toCKRecord() -> CKRecord
+}

--- a/Junction/Info.plist
+++ b/Junction/Info.plist
@@ -13,5 +13,9 @@
 		<string>Pretendard-SemiBold.otf</string>
 		<string>Pretendard-Medium.otf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Junction/Infrastructure/CloudKitManager.swift
+++ b/Junction/Infrastructure/CloudKitManager.swift
@@ -1,0 +1,101 @@
+//
+//  CloudKitManager.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/12/24.
+//
+
+import Combine
+import CloudKit
+import UIKit
+
+class CloudKitManager {
+    static let shared = CloudKitManager()
+    let database = CKContainer.default().privateCloudDatabase
+    let cloudKitNotificationSubject = PassthroughSubject<Void, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    private init() {
+        setupCloudKitSubscription()
+        listenCloudkitNotification()
+    }
+    
+    func save(record: CKRecord) async throws {
+        do {
+            try await database.save(record)
+        } catch {
+            
+        }
+    }
+    
+    private func setupCloudKitSubscription() {
+        let subscription = CKQuerySubscription(recordType: "UserInfo",
+                                               predicate: NSPredicate(value: true),
+                                               subscriptionID: "UserInfoSubscriptionID",
+                                               options: [.firesOnRecordUpdate, .firesOnRecordCreation, .firesOnRecordDeletion])
+        let notificationInfo = CKSubscription.NotificationInfo()
+        notificationInfo.shouldSendContentAvailable = true
+        
+        subscription.notificationInfo = notificationInfo
+        
+        database.save(subscription) { subscription, error in
+            if let error = error {
+                print("Failed to create subscription: \(error)")
+            } else {
+                print("Subscription created: \(String(describing: subscription))")
+            }
+        }
+    }
+    
+    private func listenCloudkitNotification() {
+        NotificationCenter.default.publisher(for: .NSPersistentStoreRemoteChange)
+            .compactMap { notification -> [AnyHashable: Any]? in
+                notification.userInfo
+            }
+            .compactMap { userInfo -> CKQueryNotification? in
+                CKQueryNotification(fromRemoteNotificationDictionary: userInfo)
+            }
+            .sink { ckNotification in
+                if let recordID = ckNotification.recordID {
+                    self.cloudKitNotificationSubject.send()
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func fetch(recordString: String) async -> CKRecord? {
+        do {
+            let recordID = CKRecord.ID(recordName: recordString)
+            let record = try await database.record(for: recordID)
+            return record
+        } catch {  }
+        
+        return nil
+    }
+    
+    func update<T>(record: CKRecord, type: T.Type) async {
+        do {
+            try await database.save(record)
+        }
+        catch let error as CKError {
+            switch error.code {
+                case .serverRecordChanged:
+                    if let serverRecord = error.serverRecord { await handleUpdate(serverRecord: serverRecord, type: type) }
+                    
+                default: print(error)
+            }
+        } catch { print(error) }
+        
+        print("끝")
+    }
+    
+    private func handleUpdate<T>(serverRecord: CKRecord, type: T.Type) async {
+        if T.self == UserInfo.self {
+            var newRecord = serverRecord
+            newRecord["remainingTimes"]! = newRecord["remainingTimes"]! - 1
+            await update(record: newRecord, type: UserInfo.self)
+        } else if T.self == HealthInfo.self { await update(record: serverRecord, type: HealthInfo.self) }
+        else { print("Unknown Type") }
+        
+    }
+}

--- a/Junction/Infrastructure/SwiftDataManager.swift
+++ b/Junction/Infrastructure/SwiftDataManager.swift
@@ -1,0 +1,52 @@
+//
+//  SwiftDataManager.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/11/24.
+//
+
+import Foundation
+import SwiftData
+import Combine
+
+class SwiftDataManager {
+    static let shared = SwiftDataManager()
+    
+    private(set) var container: ModelContainer
+    private var modelContext: ModelContext
+    
+    private init() {
+        do {
+            let config = ModelConfiguration(allowsSave: true, cloudKitDatabase: .none)
+            let schema = Schema([UserInfo.self, HealthInfo.self])
+            container = try ModelContainer(for: schema, configurations: config)
+        } catch { fatalError("\(error.localizedDescription)") }
+        
+        modelContext = ModelContext(container)
+    }
+    
+    private func save() {
+        do { try modelContext.save() }
+        catch { print(error) }
+    }
+    
+    func saveData<T: PersistentModel>(_ data: T) {
+        print(#function)
+        modelContext.insert(data)
+        save()
+    }
+    
+    func fetchLatest<T: PersistentModel>(data: T.Type) -> T? {
+        do {
+            let healthInfos = try modelContext.fetch(FetchDescriptor<T>())
+            return healthInfos.last
+        } catch { print(error) }
+        
+        return nil
+    }
+    
+    func delete<T: PersistentModel>(data: T) {
+        modelContext.delete(data)
+        save()
+    }
+}

--- a/Junction/Junction.entitlements
+++ b/Junction/Junction.entitlements
@@ -2,9 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.Eric.motive.prelude</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/Junction/JunctionApp.swift
+++ b/Junction/JunctionApp.swift
@@ -6,13 +6,17 @@
 //
 
 import SwiftUI
+import SwiftData
 
 @main
 struct JunctionApp: App {
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+//            MainView()
                 .environmentObject(NavigationManager())
+                .modelContainer(SwiftDataManager.shared.container)
         }
     }
 }

--- a/Junction/Presentation/ViewModels/HealthCheckViewModel.swift
+++ b/Junction/Presentation/ViewModels/HealthCheckViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  HealthCheckViewModel.swift
+//  Junction
+//
+//  Created by 송지혁 on 10/12/24.
+//
+
+import CloudKit
+import Foundation
+
+class HealthCheckViewModel: ObservableObject {
+    
+    private let cloudkitManager: CloudKitManager
+    private let swiftDataManager: SwiftDataManager
+    
+    init(cloudkitManager: CloudKitManager = CloudKitManager.shared, swiftDataManager: SwiftDataManager = SwiftDataManager.shared) {
+        self.cloudkitManager = cloudkitManager
+        self.swiftDataManager = swiftDataManager
+    }
+    
+    func submit(healthInfo: HealthInfo) async {
+        let result = await cloudkitManager.fetch(recordString: "UserInfo")
+        
+        if let record = result {
+            guard let userInfo = UserInfo(from: record, healthInfo: healthInfo) else { return }
+            swiftDataManager.saveData(userInfo)
+        } else {
+            let newUserInfo = UserInfo(remainingTimes: 0, healthInfo: healthInfo)
+            swiftDataManager.saveData(newUserInfo)
+        }
+    }
+    
+    
+    
+    
+}

--- a/Junction/Presentation/ViewModels/HealthSetUpViewModel.swift
+++ b/Junction/Presentation/ViewModels/HealthSetUpViewModel.swift
@@ -51,18 +51,18 @@ class HealthInfoSetUpViewModel: ObservableObject {
             .eraseToAnyPublisher()
     }
     
-    func submit(navigationManager: NavigationManager) {
+    func submit(completion: @escaping (Result<HealthInfo, Error>) -> Void) {
         makeHealthInfo()
-            .sink { completion in
-                switch completion {
+            .sink(receiveCompletion: { completionStatus in
+                switch completionStatus {
                     case .finished:
                         break
                     case .failure(let error):
-                        print("Error occurred: \(error.localizedDescription)")
+                        completion(.failure(error))
                 }
-            } receiveValue: { healthInfo in
-                navigationManager.screenPath.append(.healthCheck(healthInfo: healthInfo))
-            }
+            }, receiveValue: { healthInfo in
+                completion(.success(healthInfo))
+            })
             .store(in: &cancellables)
     }
     

--- a/Junction/Presentation/ViewModels/ResultViewModel.swift
+++ b/Junction/Presentation/ViewModels/ResultViewModel.swift
@@ -30,7 +30,6 @@ class ResultViewModel: ObservableObject {
     )) {
         
         self.assistantInteractionFacade = assistantInteractionFacade
-        self.loadHealthInfo()
         
         $userHealthInfo
             .sink { healthInfo in
@@ -66,14 +65,5 @@ class ResultViewModel: ObservableObject {
                 })
                 .store(in: &self.cancellables)
         }.eraseToAnyPublisher()
-    }
-    
-    func loadHealthInfo() {
-        if let data = UserDefaults.standard.data(forKey: "HealthInfo") {
-            let decoder = JSONDecoder()
-            if let healthInfo = try? decoder.decode(HealthInfo.self, from: data) {
-                self.userHealthInfo = healthInfo
-            }
-        }
     }
 }

--- a/Junction/Presentation/Views/HealthCheckView.swift
+++ b/Junction/Presentation/Views/HealthCheckView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HealthCheckView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @Environment(\.dismiss) var dismiss
+    @StateObject var healthCheckViewModel = HealthCheckViewModel()
     let healthInfo: HealthInfo
     
     var body: some View {
@@ -57,8 +58,10 @@ struct HealthCheckView: View {
                         }
                     
                         .onTapGesture {
-                            saveHealthInfo()
-                            navigationManager.screenPath.append(.main)
+                            Task {
+                                await healthCheckViewModel.submit(healthInfo: healthInfo)
+                                await MainActor.run { navigationManager.screenPath.append(.main) }
+                            }
                         }
                         .padding(.trailing, 24)
                     
@@ -68,17 +71,6 @@ struct HealthCheckView: View {
             .navigationBarBackButtonHidden()
         }
         .ignoresSafeArea()
-    }
-    
-    private func saveHealthInfo() {
-        do {
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(healthInfo)
-            UserDefaults.standard.set(data, forKey: "HealthInfo")
-            print("HealthInfo saved successfully.")
-        } catch {
-            print("Failed to save HealthInfo: \(error)")
-        }
     }
     
     private var instructions: some View {

--- a/Junction/Presentation/Views/HealthInfoSetUpView.swift
+++ b/Junction/Presentation/Views/HealthInfoSetUpView.swift
@@ -93,7 +93,9 @@ health information
                     
                 }
                 .onTapGesture {
-                    viewModel.submit(navigationManager: navigationManager)
+                    viewModel.submit { result in
+                        if case .success(let healthInfo) = result { navigationManager.screenPath.append(.healthCheck(healthInfo: healthInfo)) }
+                    }
                 }
                 .disabled(viewModel.formCheck())
                 .padding(.horizontal, 24)

--- a/Junction/Presentation/Views/MainView.swift
+++ b/Junction/Presentation/Views/MainView.swift
@@ -17,6 +17,7 @@ struct MainView: View {
     @State private var healthInfo: HealthInfo?
     @State private var foodName = ""
     
+    
     let headerText = """
     Tell us about the food
     you’re worried about
@@ -41,6 +42,18 @@ struct MainView: View {
                     .padding(.horizontal, 24)
                 
                 Spacer()
+                
+                Text("remaining Times: \(mainViewModel.userInfo?.remainingTimes ?? 0)")
+                
+                Rectangle()
+                    .fill(.green)
+                    .frame(height: 50)
+                    .onTapGesture {
+                        Task {
+                            await mainViewModel.submit()
+                        }
+                    }
+                
                 
                 Text("Done")
                     .font(.pretendBold16)
@@ -103,7 +116,12 @@ struct MainView: View {
         }
         .ignoresSafeArea()
         .navigationBarBackButtonHidden()
+        .onAppear {
+            guard mainViewModel.userInfo == nil else { return }
+            mainViewModel.fetchUserInfo()
+        }
     }
+    
     
     private var header: some View {
         HStack {

--- a/Junction/Presentation/Views/MainView.swift
+++ b/Junction/Presentation/Views/MainView.swift
@@ -6,15 +6,13 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct MainView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @StateObject var mainViewModel = MainViewModel()
-    
-    
     @State private var uiImage: UIImage?
     @State private var isShowingImagePicker = false
-    @State private var healthInfo: HealthInfo?
     @State private var foodName = ""
     
     
@@ -73,43 +71,6 @@ struct MainView: View {
                     .padding(.bottom, 36)
                     .padding(.horizontal, 24)
             }
-            
-            
-            
-            //            Button("테스트") {
-            //                mainViewModel.sendMessageForQuiz("이 임산부의 건강 상태는 혈압 낮음, 당뇨 없음, 임신 초기야.", image: uiImage)
-            //            }
-            //
-            //            Button("health") {
-            //                healthInfo = mainViewModel.loadHealthInfo()
-            //            }
-            //
-            //            Text(healthInfo?.bloodPressure.rawValue ?? "안됨 저장")
-            //
-            //
-            //            Button(action: {
-            //                isShowingImagePicker = true
-            //            }) {
-            //                Text("Open Camera")
-            //                    .padding()
-            //                    .background(Color.blue)
-            //                    .foregroundColor(.white)
-            //                    .cornerRadius(10)
-            //            }
-            //
-            //            ScrollView {
-            //                Text(mainViewModel.judgement?.recognition.description ?? "")
-            //                Text(mainViewModel.judgement?.productName ?? "")
-            //                Text(mainViewModel.judgement?.conclusion ?? "")
-            //                ForEach(mainViewModel.judgement?.details ?? [JudgementDetail(title: "", content: "")], id: \.self) { detail in
-            //                    VStack {
-            //                        Text(detail.title)
-            //                            .bold()
-            //
-            //                        Text(detail.content)
-            //                    }
-            //                }
-            //            }
             .sheet(isPresented: $isShowingImagePicker) {
                 ImagePicker(image: $uiImage, sourceType: .camera)
             }
@@ -213,7 +174,6 @@ struct MainView: View {
                 .padding(.vertical, 13)
                 .padding(.leading, 14)
                 .background { RoundedRectangle(cornerRadius: 16).stroke(.gray8, lineWidth: 1) }
-            
         }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> CloudKit과 SwiftData를 사용해 iCloud로 유저 데이터를 연동하는 기능을 구현했습니다.

## 🔐 세부 내용
> ### `CloudKit`을 사용하여 사용자 iCloud를 데이터베이스로 사용
>- `CloudKit` CRUD를 수동으로 구현하여 사용자의 iCloud를 `private database`로 사용합니다.
>- `SwiftData` CRUD를 구현하여 사용자 정보를 디바이스 로컬에 저장하여 네트워크 의존성을 감소시키고, 읽기/쓰기 성능을 향상시켰습니다.
>- 로컬 데이터베이스(`SwiftData`)와 클라우드 데이터베이스(`CloudKit`)를 수동으로 연동했습니다.

<br />

## 🎮 특이 사항

> ### 로컬 데이터베이스와 클라우드 데이터의 연동을 수동으로 구현한 이유
>- `CloudKit`은 서버 측 로직을 실행하는 기능을 제공하지 않아 로컬 디바이스에서 직접 데이터를 업데이트해야 합니다.
>- `SwiftData`는 `CloudKit`을 이용한 `private database`와 자동으로 연동하는 기능을 제공하지만, 연동 중 발생하는 `Error`를 캐치할 수 없는 이슈가 있었습니다. 
>- 동일한 iCloud 계정에 로그인되어있는 두 디바이스에서 동시에 클라우드 내 같은 레코드를 변경할 때, 
`CKErrror.serverRecordChanged`를 캐치하지 못하고 내부적으로 가장 마지막에 도착한 데이터를 덮어쓰는 상황이 발생했습니다.
사용자의 결제 정보와 개인 건강 정보 등의 **중요도가 높은 데이터**가 저장되는 플로우였기 때문에
서버의 레코드와 클라이언트 레코드의`changeTag`가 일치하지 않는 상황을 캐치해 연동 로직을 따로 구현했습니다.

<br />

> ### iCloud 연동 방식의 데이터 무결성 위반 가능성
>- `CloudKit`에서 데이터 무결성을 위한 여러 기능을 제공하고 있지만, 개발자가 수동으로 구현하는만큼 클라이언트에서 예상치 못한 시나리오로 접근했을 때가 상당히 두려움.

<br />

> ### 안드로이드로의 확장 가능성 없음
>- 애플 플랫폼 중심의 데이터베이스이기 때문에 추후 안드로이드 버전을 출시할 때, 같은 데이터베이스를 사용할 수 없음. 이 시점이 오기 전에 플랫폼 중립적인 서버 사용이 필수적일 것 같습니다.
